### PR TITLE
Fix issue in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ zig-cache
 zig-out
 .direnv
 result
+zig-result

--- a/examples/ping/main.zig
+++ b/examples/ping/main.zig
@@ -1,24 +1,12 @@
 const std = @import("std");
-const os = std.os;
-const okredis = @import("okredis");
 const MsQuic = @import("msquic");
 const libp2p = @import("libp2p");
-const multiaddr = libp2p.multiaddr;
-const MemoryPool = libp2p.util.MemoryPool;
-const crypto = libp2p.crypto;
 const CredentialConfigHelper = @import("libp2p-msquic").crypto.CredentialConfigHelper;
 const getPeerPubKey = @import("libp2p-msquic").crypto.getPeerPubKey;
+const multiaddr = libp2p.multiaddr;
 const log = std.log;
 const ping = libp2p.protocols.ping;
 const TestNode = libp2p.util.test_util.TestNode;
-
-const Allocator = std.mem.Allocator;
-const QuicStatus = MsQuic.QuicStatus;
-const ArrayList = std.ArrayList;
-const Instant = std.time.Instant;
-const Semaphore = std.Thread.Semaphore;
-
-const stdout = std.io.getStdOut();
 
 const TestPingStreamContext = ping.TestPingStreamContext;
 

--- a/flake.nix
+++ b/flake.nix
@@ -85,7 +85,7 @@
               # cp -r . $build_dir
               # cd $build_dir
               export HOME=$PWD
-              ${zig}/bin/zig build interop
+              ${zig}/bin/zig build -Dcpu=generic interop
             '';
             installPhase = ''
               cp -r zig-out $out

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
       {
         packages.libmsquic = zig-msquic-flake.packages.${system}.libmsquic;
         packages.libmsquic-debug = zig-msquic-flake.packages.${system}.libmsquic-debug;
+        packages.zig = zig;
         packages.zls = zls.packages.${system}.default;
         # packages.zls = pkgs.stdenvNoCC.mkDerivation {
         #   name = "zls";

--- a/flake.nix
+++ b/flake.nix
@@ -63,9 +63,14 @@
           {
             name = "interop-binary";
             src = ./.;
-            nativeBuildInputs = [
-              pkgs.autoPatchelfHook # Automatically setup the loader, and do the magic
-            ];
+            nativeBuildInputs =
+              (if pkgs.stdenv.isDarwin
+              then
+                (with pkgs.darwin.apple_sdk.frameworks;
+                [ ])
+              else [
+                pkgs.autoPatchelfHook # Automatically setup the loader, and do the magic
+              ]);
             buildInputs = [
               zig
               openssl

--- a/flake.nix
+++ b/flake.nix
@@ -85,7 +85,7 @@
               # cp -r . $build_dir
               # cd $build_dir
               export HOME=$PWD
-              ${zig}/bin/zig build -Dcpu=generic interop
+              ${zig}/bin/zig build ${(if (pkgs.stdenv.isLinux && pkgs.stdenv.isx86_64) then  "-Dcpu=x86_64" else "")} interop
             '';
             installPhase = ''
               cp -r zig-out $out

--- a/interop/Dockerfile
+++ b/interop/Dockerfile
@@ -35,6 +35,11 @@ RUN mkdir /tmp/nix-store-closure
 RUN echo "Output references (Runtime dependencies):" $(nix-store -qR result/)
 RUN cp -R $(nix-store -qR result/) /tmp/nix-store-closure
 
+
+# Copy zig binary for debugging
+RUN nix build -o zig-result .#zig
+RUN cp -R $(nix-store -qR zig-result/) /tmp/zig-nix-store-closure
+
 # Our production stage
 FROM scratch
 WORKDIR /app
@@ -44,4 +49,5 @@ WORKDIR /app
 # Nix.
 COPY --from=builder /tmp/nix-store-closure /nix/store
 COPY --from=builder /app/result /app
+COPY --from=builder /app/zig-result/ /app/zig
 CMD ["/app/bin/interop"]


### PR DESCRIPTION
The problem is that we compile for our host architecture making use of any features the host cpu has. That's normally great, but in this case we want a portable binary. I believe the issue in https://github.com/libp2p/test-plans/issues/169 is that the CI runners are not uniform. The runner that failed here had an older CPU then the one that build the binary originally.

This targets a generic `x86_64` when you build with `nix build .#interop` to fix this issue.

It also adds the zig binary into the final image so that we can print out the cpu info when we run the test to help debug this issue.