### PR TITLE
Non optimistic MSS listener

### DIFF
--- a/src/protocols/ping.zig
+++ b/src/protocols/ping.zig
@@ -213,7 +213,7 @@ pub const Handler = struct {
     }
 };
 
-pub const HandlerWithMSS = mss.WrapHandlerWithMSS(Handler);
+pub const HandlerWithMSS = mss.WrapHandlerWithMSSNonOptimisticListener(Handler);
 
 const TestEnv = @import("../util/test_util.zig").TestEnv(void);
 var test_supported_protos = [_][]const u8{id};


### PR DESCRIPTION
Fixes an issue where the listener would delay sending the MSS back assuming the other side was optimistic. The reason being that we can send a single packet with the MSS header and application data rather than a small packet with the MSS header and another one with application data. However, if the otherside is not optimistic, it will stall waiting for the MSS header before sending application data, and if our listener doesn't do anything until it receives application data (e.g. ping) we will never have more data to send and possibly never send the MSS header.

I think there's some logic in MsQuic that happens to send our delayed MSS header sometimes, and I think this causes this to be a flaky on when it shows up.