### PR TITLE
chore(cfg): add issue template with links to discussion forums

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug Report
+description: Create a bug report for zig-libp2p
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for filing a bug report!
+  - type: textarea
+    attributes:
+      label: Summary
+      description: Please provide a short summary of the bug, along with any information you feel relevant to replicate the bug.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: Describe what you expect to happen.    
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual behavior
+      description: Describe what actually happens.    
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label:  Possible Solution
+      description: Suggest a fix/reason for the bug, or ideas how to implement the addition or change. 
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Version
+      description: Which version of libp2p are you using? libp2p version (version number, commit, or branch)
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      label: Would you like to work on fixing this bug ?
+      description: Any contribution towards fixing the bug is greatly appreciated. We are more than happy to provide help on the process.
+      options:
+        - "Yes"
+        - "No"
+        - Maybe
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Technical Questions
+    url: https://github.com/libp2p/zig-libp2p/discussions/new?category=q-a
+    about: Please ask technical questions in the zig-libp2p Github Discussions forum.
+  - name: Community-wide libp2p Discussion
+    url: https://discuss.libp2p.io
+    about: Discussions and questions about the libp2p community.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,31 @@
+name: Enhancement
+description: Suggest an improvement to an existing zig-libp2p feature.
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: Describe the enhancement that you are proposing.    
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Explain why this enhancement is beneficial.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Current Implementation
+      description: Describe the current implementation.
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Are you planning to do it yourself in a pull request ?
+      description: Any contribution is greatly appreciated. We are more than happy to provide help on the process.
+      options:
+        - "Yes"
+        - "No"
+        - Maybe
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest a new feature in zig-libp2p
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If you'd like to suggest a feature related to libp2p but not specifically related to the Zig implementation, please file an issue at https://github.com/libp2p/specs instead.
+  - type: textarea
+    attributes:
+      label: Description
+      description: Briefly describe the feature that you are requesting.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Explain why this feature is needed.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Requirements
+      description: Write a list of what you want this feature to do.
+      placeholder: "1." 
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Open questions
+      description: Use this section to ask any questions that are related to the feature.
+    validations:
+      required: false
+  - type: dropdown
+    attributes:
+      label: Are you planning to do it yourself in a pull request ?
+      description: Any contribution is greatly appreciated. We are more than happy to provide help on the process.
+      options:
+        - "Yes"
+        - "No"
+        - Maybe
+    validations:
+      required: true


### PR DESCRIPTION
This sets up an new issue templates with links to the technical discussion forum in the zig-libp2p repo as well as a link to the libp2p community-wide forum.