### PR TITLE
Update ZLS

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,18 +1,22 @@
 {
   "nodes": {
-    "diffz": {
+    "flake-compat": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-9bdX4R/VDdjAn8TDH4T3a783mvbpjdWq2KSNtM9RcnY=",
-        "type": "tarball",
-        "url": "https://github.com/ziglibs/diffz/archive/b966296b4489eb082b0831ec9a37d6f5e1906040.tar.gz"
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/ziglibs/diffz/archive/b966296b4489eb082b0831ec9a37d6f5e1906040.tar.gz"
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
       }
     },
-    "flake-compat": {
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1673956053,
@@ -43,6 +47,39 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -51,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -64,16 +101,16 @@
         "type": "github"
       }
     },
-    "known_folders": {
+    "langref": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-hgzm6HrtusbhmWEq6moKYGf5sWc52UwyHTjAIjr6EEQ=",
-        "type": "tarball",
-        "url": "https://github.com/ziglibs/known-folders/archive/d13ba6137084e55f873f6afb67447fe8906cc951.tar.gz"
+        "narHash": "sha256-94broSBethRhPJr0G9no4TPyB8ee6BQ/hHK1QnLPln0=",
+        "type": "file",
+        "url": "https://raw.githubusercontent.com/ziglang/zig/54bbc73f8502fe073d385361ddb34a43d12eec39/doc/langref.html.in"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/ziglibs/known-folders/archive/d13ba6137084e55f873f6afb67447fe8906cc951.tar.gz"
+        "type": "file",
+        "url": "https://raw.githubusercontent.com/ziglang/zig/54bbc73f8502fe073d385361ddb34a43d12eec39/doc/langref.html.in"
       }
     },
     "nixpkgs": {
@@ -108,6 +145,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1712757991,
+        "narHash": "sha256-kR7C7Fqt3JP40h0mzmSZeWI5pk1iwqj4CSeGjnUbVHc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d6b3ddd253c578a7ab98f8011e59990f21dc3932",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -117,16 +170,19 @@
         "zls": "zls"
       }
     },
-    "tres": {
-      "flake": false,
+    "systems": {
       "locked": {
-        "narHash": "sha256-WFI/nXcxy05kfrl4kLjP0LfwO9xCqjxKg7ZPEKiB6NY=",
-        "type": "tarball",
-        "url": "https://github.com/ziglibs/tres/archive/707a09313b42e05d6ae22d1590499eece5f968ce.tar.gz"
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/ziglibs/tres/archive/707a09313b42e05d6ae22d1590499eece5f968ce.tar.gz"
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "zig-overlay": {
@@ -153,33 +209,47 @@
         "type": "github"
       }
     },
-    "zls": {
+    "zig-overlay_2": {
       "inputs": {
-        "diffz": "diffz",
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "gitignore": "gitignore",
-        "known_folders": "known_folders",
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
-          "nixpkgs-unstable"
-        ],
-        "tres": "tres",
-        "zig-overlay": [
-          "zig-overlay"
+          "zls",
+          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1679342566,
-        "narHash": "sha256-k678frL0kT8cPcTkRG3yyzQYksOw8y+Bxo+wtHDEG7U=",
-        "owner": "marcopolo",
-        "repo": "zls",
-        "rev": "74cef3f332658519305b89a02a2d11d8a9fabfdd",
+        "lastModified": 1712794997,
+        "narHash": "sha256-H1sVVagnlL6xmvSVELGMEAhvJHv4auAY3B97Oi2I8uo=",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "rev": "9687044a467176bea9e3f0a972143bcbad5dae90",
         "type": "github"
       },
       "original": {
-        "owner": "marcopolo",
-        "ref": "master",
+        "owner": "mitchellh",
+        "repo": "zig-overlay",
+        "type": "github"
+      }
+    },
+    "zls": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "gitignore": "gitignore",
+        "langref": "langref",
+        "nixpkgs": "nixpkgs_2",
+        "zig-overlay": "zig-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1713742752,
+        "narHash": "sha256-mVc0Kig80StZd3rLYuDVJ3jvFmEFepJubfzttuBOS48=",
+        "owner": "zigtools",
+        "repo": "zls",
+        "rev": "07508440588bf06f041da9f6dd3956948368f194",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zigtools",
         "repo": "zls",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -28,22 +28,6 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1644229661,
@@ -51,21 +35,6 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -171,34 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1677198262,
-        "narHash": "sha256-PxZ6JdfvNVI/+EIjhaW28EkQqafUnm4VouT31swPqOc=",
+        "lastModified": 1713960597,
+        "narHash": "sha256-WAryNIrMfZ48iZSTh8hcHIX9vwh78LMFUtewgY7kp1Y=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "799650b2e991ea6f4b581d6eea3c8501f7937108",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "type": "github"
-      }
-    },
-    "zig-overlay_2": {
-      "inputs": {
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": [
-          "zls",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1679314146,
-        "narHash": "sha256-+qzjv9xsGvQDAO3tJT03S7zQvWhOUidndHygYHJC1zA=",
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "rev": "4bcd5d75b0d5406c02dee62e507af9ecc77a85d9",
+        "rev": "71894accd2dd096f5a84166a628b1f075311aafe",
         "type": "github"
       },
       "original": {
@@ -219,7 +165,9 @@
           "nixpkgs-unstable"
         ],
         "tres": "tres",
-        "zig-overlay": "zig-overlay_2"
+        "zig-overlay": [
+          "zig-overlay"
+        ]
       },
       "locked": {
         "lastModified": 1679342566,

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     url = "github:marcopolo/zls/master";
     inputs = {
       nixpkgs.follows = "nixpkgs-unstable";
-      # zig-overlay.follows = "zig-overlay";
+      zig-overlay.follows = "zig-overlay";
       flake-utils.follows = "flake-utils";
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -10,14 +10,7 @@
       flake-utils.follows = "flake-utils";
     };
   };
-  inputs.zls = {
-    url = "github:marcopolo/zls/master";
-    inputs = {
-      nixpkgs.follows = "nixpkgs-unstable";
-      zig-overlay.follows = "zig-overlay";
-      flake-utils.follows = "flake-utils";
-    };
-  };
+  inputs.zls.url = "github:zigtools/zls";
 
 
   outputs = { self, nixpkgs, nixpkgs-unstable, flake-utils, zig-overlay, zls }@inputs:


### PR DESCRIPTION
Previous 'master' zig build is no longer… available and ZLS references it. Ideally the ZLS flake should let us specify a version that is long lived.

Closes #14 